### PR TITLE
Make sure entries are never null

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerPublisher.java
@@ -40,6 +40,14 @@ public class ArtifactDeployerPublisher extends Recorder implements MatrixAggrega
     public ArtifactDeployerPublisher(List<ArtifactDeployerEntry> deployedArtifact, boolean deployEvenBuildFail) {
         this.entries = deployedArtifact;
         this.deployEvenBuildFail = deployEvenBuildFail;
+        if(this.entries == null)
+        	this.entries = Collections.emptyList();
+    }
+    
+    public Object readResolve() {
+    	if(this.entries == null)
+    		this.entries = Collections.emptyList();
+    	return this;
     }
 
     public BuildStepMonitor getRequiredMonitorService() {


### PR DESCRIPTION
If user doesn't add artifact to deploy, build fails with NPE. Making sure that enties are never null builds finish more gracefully in such cases.
