### PR TITLE
check if outputFilePath exists before creating

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuilder.java
@@ -75,7 +75,9 @@ public class ArtifactDeployerBuilder extends Builder implements Serializable {
         //Creating the remote directory
         final FilePath outputFilePath = new FilePath(workspace.getChannel(), outputPath);
         try {
-            outputFilePath.mkdirs();
+            if (outputFilePath.exists() == false) {
+                outputFilePath.mkdirs();
+            }
         } catch (IOException ioe) {
             throw new ArtifactDeployerException(String.format("Can't create the directory '%s'", outputPath), ioe);
         }


### PR DESCRIPTION
If `outputFilePath` exists `ArtifactDeployer` dies with an exception when calling `.mkdirs()`.

This fix checks for existence before creation to prevent the error.

I would appreciate some clarification on whether I am simply misunderstanding how ArtifactDeployer operates or if this is indeed an error.
