### PR TITLE
Update help-includes.html, fix typo and add description

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuilder/help-includes.html
+++ b/src/main/resources/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuilder/help-includes.html
@@ -3,6 +3,6 @@
         Can use wildcards like 'module/dist/**/*.zip'. See the <a
             href="http://ant.apache.org/manual/Types/fileset.html">@includes of Ant fileset</a> for the exact
         format.<br/>
-        Files are deployed from the the workspace. You can change this basedir by specifying the basedir field.
+        Files are deployed from the workspace. You can change this basedir by specifying the basedir field under Advanced.
     </p>
 </div>


### PR DESCRIPTION
There was a double 'the' in the description and I added the location of the basedir config
