### PR TITLE
[WIP] Make Matrix dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <version>1.3</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.atlassian</groupId>

--- a/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerPublisher.java
@@ -69,6 +69,12 @@ public class ArtifactDeployerPublisher extends Recorder implements Serializable 
     public Object readResolve() {
         if (this.entries == null)
             this.entries = Collections.emptyList();
+
+        if (Jenkins.getInstance().getPlugin("maven-project") != null)
+            // To do it right, Would need to detect parent project is a Matrix one
+            // anyway, until project is re-saved this is ok to rely on this superclass
+            return new MatrixArtifactDeployerPublisher(entries, deployEvenBuildFail);
+
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/artifactdeployer/MatrixArtifactDeployerPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactdeployer/MatrixArtifactDeployerPublisher.java
@@ -1,0 +1,60 @@
+package org.jenkinsci.plugins.artifactdeployer;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.matrix.MatrixAggregatable;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixConfiguration;
+import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixRun;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Extends ArtifactDeployerPublisher to support Matrix projects and implement MatrixAggregatable.
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class MatrixArtifactDeployerPublisher extends ArtifactDeployerPublisher implements MatrixAggregatable {
+
+    @DataBoundConstructor
+    public MatrixArtifactDeployerPublisher(List<ArtifactDeployerEntry> deployedArtifact, boolean deployEvenBuildFail) {
+        super(deployedArtifact, deployEvenBuildFail);
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        if (build.getProject() instanceof MatrixConfiguration) return true;
+        return super.perform(build, launcher, listener);
+    }
+
+    public MatrixAggregator createAggregator(final MatrixBuild build, final Launcher launcher, final BuildListener listener) {
+        return new MatrixAggregator(build, launcher, listener) {
+
+            @Override
+            public boolean endRun(MatrixRun run) throws InterruptedException, IOException {
+                boolean result = MatrixArtifactDeployerPublisher.super.perform((AbstractBuild) run, launcher, listener);
+                run.save();
+                return result;
+            }
+
+        };
+    }
+
+    @Extension(optional = true)
+    @SuppressWarnings("unused")
+    public static final class DescriptorImpl extends ArtifactDeployerDescriptor {
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return jobType.isAssignableFrom(MatrixProject.class);
+        }
+
+
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/artifactdeployer/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/artifactdeployer/Messages.properties
@@ -1,1 +1,1 @@
-depployerartifact.displayName=[ArtifactDeployer] - Deploy the artifacts from build workspace to remote locations
+depployerartifact.displayName=Deploy the artifacts from build workspace to remote locations


### PR DESCRIPTION
A second Publisher do specialize ArtifactDeployerPublisher for matrix project handling
ArtifactDeployerPublisher discards itself when another publisher do better match the current project type
