### PR TITLE
chore: add contributor docs, PR template, MIT license, and Copilot guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,56 @@
+# Copilot Instructions - Jenkins Plugin (Generic)
+
+This file guides GitHub Copilot and AI assistants for Jenkins plugin repositories.
+The goal is consistent, safe, and reviewable contributions across plugins.
+
+## Project baseline
+
+- Project type: Jenkins plugin (Maven, HPI packaging)
+- Main language: Java
+- UI technology may include Jelly, JavaScript, and CSS
+- Default branch is usually `master` unless the repo states otherwise
+
+## Issue and PR linking
+
+- Link GitHub issues as `#123`.
+- Use closing keywords (`Fixes #123`) only when fully resolved.
+- Minor maintenance tasks may not need an issue unless maintainers request one.
+
+## Commit and PR title conventions
+
+- PR title is used as changelog text: use imperative mood.
+- Keep titles clear and scoped to one change.
+- Prefer one logical change per PR.
+
+## Coding rules
+
+- Keep public API additions intentional and documented.
+- Mark internal-only APIs with Jenkins access restriction annotations when needed.
+- Avoid inline JavaScript and avoid `eval()`.
+- Add comments only where they improve maintainability.
+- Follow existing code style and plugin conventions.
+
+## Localization
+
+- Do not hardcode user-facing strings where localization is used.
+- Add English keys to `*.properties` files for new UI text.
+
+## Testing expectations
+
+- Every non-trivial code change should include tests or a clear rationale when tests are not feasible.
+- For behavior changes, explain test scenarios in the PR description.
+- For UI changes, include screenshots when useful.
+
+## Dependency updates
+
+- Prefer small, isolated dependency PRs.
+- Include links to release notes/changelogs when helpful.
+- Flag breaking changes explicitly.
+
+## Maintainer pre-merge checklist
+
+1. PR description matches actual changes.
+2. Linked issue(s) are correct when present.
+3. Required CI checks are green.
+4. At least one approval for non-trivial changes.
+5. No unresolved blocking comments.

--- a/.github/copilot-pr-review-rules.md
+++ b/.github/copilot-pr-review-rules.md
@@ -1,0 +1,56 @@
+# Copilot PR Review Rules (Generic)
+
+Use this checklist when reviewing, triaging, or cleaning up pull requests.
+
+## Review workflow
+
+### 1. Validate PR description
+
+- Confirm title/body accurately describe the diff.
+- Flag stale template text and mismatches.
+
+### 2. Validate linked issues
+
+- Confirm linked GitHub issues match the change intent.
+- Minor chores may not require an issue unless repository policy says otherwise.
+
+### 3. Validate implementation quality
+
+- Check that code solves the stated problem.
+- Flag unrelated changes, dead code, and debug leftovers.
+- Ensure consistency with repository coding conventions.
+
+### 4. Review comments context
+
+- Open comments must be resolved or clearly acknowledged.
+- Read resolved comments for context and prior decisions.
+
+### 5. Require a clear continuation plan
+
+- If work is incomplete, propose explicit next steps.
+- Recommend split PRs when changes are mixed.
+
+### 6. Define and verify testing
+
+- Request both manual validation steps and automated test coverage for non-trivial changes.
+- If tests are missing, require justification.
+- Prefer running full verification before merge when feasible:
+
+```bash
+mvn -ntp clean verify
+```
+
+### 7. Branch hygiene
+
+- Source branch should be up to date with target branch before merge.
+- Confirm target branch is correct for the repository workflow.
+
+## Quick checklist
+
+- [ ] Description matches code changes
+- [ ] Linked issues are correct (if present)
+- [ ] Implementation is complete and scoped
+- [ ] Open comments are resolved or acknowledged
+- [ ] Testing is documented and adequate
+- [ ] Branch is up to date with target
+- [ ] Target branch is correct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+Thanks for your interest in contributing to this plugin.
+
+## How to contribute
+
+- Fork the repository and create a feature branch
+- Keep changes focused and easy to review
+- Run tests locally before opening a PR
+- Open a pull request with a clear description
+
+## Development
+
+```bash
+mvn -ntp clean verify
+```
+
+## Code of Conduct
+
+Please follow the Jenkins community standards and be respectful in all interactions.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jenkins project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What does this PR do?
+
+<!-- Briefly describe the change -->
+
+## Why is this change needed?
+
+<!-- Explain the motivation / context -->
+
+## Testing done
+
+- [ ] Local build/tests
+- [ ] Relevant manual verification
+
+## Checklist
+
+- [ ] PR title is concise and imperative
+- [ ] Documentation updated if needed
+- [ ] No breaking changes (or clearly documented)


### PR DESCRIPTION
## What does this PR do?

Adds missing repository community and guidance files used across modernized Jenkins plugin repositories.

## Changes

- Add LICENSE.txt (MIT)
- Add PULL_REQUEST_TEMPLATE.md
- Add CONTRIBUTING.md
- Add .github/copilot-instructions.md
- Add .github/copilot-pr-review-rules.md

## Why

These files improve contributor onboarding, review consistency, and Copilot-assisted contribution quality.

## Checklist

- [x] Documentation-only / process-only changes
- [x] No runtime plugin behavior changes