### PR TITLE
fix: address security scan findings (CSRF, permission checks, unsafe Callable)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuilder.java
@@ -39,6 +39,7 @@ import org.jenkinsci.plugins.artifactdeployer.service.DeployedArtifactsActionMan
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -254,17 +255,22 @@ public class ArtifactDeployerBuilder extends Builder implements Serializable {
             return DISPLAY_NAME;
         }
 
+        @POST
         public FormValidation doCheckIncludes(@AncestorInPath AbstractProject project, @QueryParameter String value) throws IOException {
+            project.checkPermission(Item.CONFIGURE);
             return FilePath.validateFileMask(project.getSomeWorkspace(), value);
         }
 
+        @POST
         public FormValidation doCheckExcludes(@AncestorInPath AbstractProject project, @QueryParameter String value) throws IOException {
+            project.checkPermission(Item.CONFIGURE);
             if (value == null || value.trim().length() == 0) {
                 return FormValidation.ok();
             }
             return FilePath.validateFileMask(project.getSomeWorkspace(), value);
         }
 
+        @POST
         public FormValidation doCheckRemote(@QueryParameter String value) throws IOException {
             if (value == null || value.trim().length() == 0) {
                 throw FormValidation.error("Remote directory is mandatory.");

--- a/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerPublisher.java
@@ -42,6 +42,7 @@ import org.jenkinsci.plugins.artifactdeployer.service.DeployedArtifactsActionMan
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -347,17 +348,22 @@ public class ArtifactDeployerPublisher extends Recorder implements MatrixAggrega
             return DISPLAY_NAME;
         }
 
+        @POST
         public FormValidation doCheckIncludes(@AncestorInPath AbstractProject project, @QueryParameter String value) throws IOException {
+            project.checkPermission(Item.CONFIGURE);
             return FilePath.validateFileMask(project.getSomeWorkspace(), value);
         }
 
+        @POST
         public FormValidation doCheckExcludes(@AncestorInPath AbstractProject project, @QueryParameter String value) throws IOException {
+            project.checkPermission(Item.CONFIGURE);
             if (value == null || value.trim().length() == 0) {
                 return FormValidation.ok();
             }
             return FilePath.validateFileMask(project.getSomeWorkspace(), value);
         }
 
+        @POST
         public FormValidation doCheckRemote(@QueryParameter String value) throws IOException {
             if (value == null || value.trim().length() == 0) {
                 return FormValidation.error("Remote directory is mandatory.");

--- a/src/main/java/org/jenkinsci/plugins/artifactdeployer/DeployedArtifactsResult.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactdeployer/DeployedArtifactsResult.java
@@ -23,6 +23,7 @@
 package org.jenkinsci.plugins.artifactdeployer;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Item;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 
@@ -77,6 +78,7 @@ public class DeployedArtifactsResult {
 
     @SuppressWarnings("unused")
     public void doDownload(final StaplerRequest2 request, final StaplerResponse2 response) throws IOException, ServletException {
+        getOwner().checkPermission(Item.READ);
 
         String restOfPath = request.getRestOfPath();
         if (restOfPath == null) {

--- a/src/main/java/org/jenkinsci/plugins/artifactdeployer/service/ArtifactDeployerCopy.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactdeployer/service/ArtifactDeployerCopy.java
@@ -26,6 +26,7 @@ import hudson.FilePath;
 import hudson.Util;
 import hudson.model.BuildListener;
 import hudson.remoting.VirtualChannel;
+import jenkins.security.Roles;
 import org.apache.tools.ant.types.FileSet;
 import org.jenkinsci.plugins.artifactdeployer.ArtifactDeployerVO;
 import org.jenkinsci.remoting.RoleChecker;
@@ -88,7 +89,7 @@ public class ArtifactDeployerCopy implements FilePath.FileCallable<List<Artifact
     }
     @Override
         public void checkRoles(RoleChecker roleChecker) throws SecurityException {
-            //We don't require any roles to be checked?
+            roleChecker.check(this, Roles.SLAVE);
         }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuildActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuildActionTest.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.artifactdeployer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ArtifactDeployerBuildActionTest {
+
+    @Test
+    void metadataMethods_shouldReturnExpectedConstants() {
+        ArtifactDeployerBuildAction action = new ArtifactDeployerBuildAction();
+
+        assertEquals("package.gif", action.getIconFileName());
+        assertEquals("Deployed Build Artifacts", action.getDisplayName());
+        assertEquals("deployedArtifacts", action.getUrlName());
+    }
+
+    @Test
+    void setArtifactsInfoAndCount_shouldExposeStoredData() {
+        ArtifactDeployerBuildAction action = new ArtifactDeployerBuildAction();
+
+        Map<Integer, List<ArtifactDeployerVO>> data = new HashMap<Integer, List<ArtifactDeployerVO>>();
+        data.put(1, Arrays.asList(new ArtifactDeployerVO(), new ArtifactDeployerVO()));
+        data.put(2, Collections.singletonList(new ArtifactDeployerVO()));
+
+        action.setArtifactsInfo(null, data);
+
+        assertSame(data.get(1), action.getDeployedArtifactsInfo().get(1));
+        assertSame(data.get(2), action.getDeployedArtifactsInfo().get(2));
+        assertEquals(3, action.getDeployedArtifactsCount());
+    }
+
+    @Test
+    void getTarget_shouldCreateDeployedArtifactsResult() {
+        ArtifactDeployerBuildAction action = new ArtifactDeployerBuildAction();
+        Object target = action.getTarget();
+
+        assertNotNull(target);
+        assertEquals(DeployedArtifactsResult.class, target.getClass());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerEntryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerEntryTest.java
@@ -1,0 +1,102 @@
+package org.jenkinsci.plugins.artifactdeployer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArtifactDeployerEntryTest {
+
+    @Test
+    void constructorAndGetters_shouldReturnConfiguredValues() {
+        ArtifactDeployerEntry entry = new ArtifactDeployerEntry(
+                "**/*.jar",
+                "target",
+                "**/*.tmp",
+                "/remote",
+                true,
+                true,
+                true,
+                true
+        );
+
+        assertEquals("**/*.jar", entry.getIncludes());
+        assertEquals("target", entry.getBasedir());
+        assertEquals("**/*.tmp", entry.getExcludes());
+        assertEquals("/remote", entry.getRemote());
+        assertTrue(entry.isFlatten());
+        assertTrue(entry.isDeleteRemote());
+        assertTrue(entry.isDeleteRemoteArtifacts());
+        assertTrue(entry.isFailNoFilesDeploy());
+    }
+
+    @Test
+    void setters_shouldUpdateAllFields() {
+        ArtifactDeployerEntry entry = new ArtifactDeployerEntry();
+
+        entry.setIncludes("a");
+        entry.setBasedir("b");
+        entry.setExcludes("c");
+        entry.setRemote("d");
+        entry.setFlatten(true);
+        entry.setDeleteRemote(true);
+        entry.setDeleteRemoteArtifacts(true);
+        entry.setDeleteRemoteArtifactsByScript(true);
+        entry.setGroovyExpression("println 'x'");
+        entry.setFailNoFilesDeploy(true);
+
+        assertEquals("a", entry.getIncludes());
+        assertEquals("b", entry.getBasedir());
+        assertEquals("c", entry.getExcludes());
+        assertEquals("d", entry.getRemote());
+        assertTrue(entry.isFlatten());
+        assertTrue(entry.isDeleteRemote());
+        assertTrue(entry.isDeleteRemoteArtifacts());
+        assertTrue(entry.isFailNoFilesDeploy());
+    }
+
+    @Test
+    void getUniqueId_shouldChangeWhenRelevantFieldChanges() {
+        ArtifactDeployerEntry entry1 = new ArtifactDeployerEntry("i", "b", "e", "r", true, false, false, false);
+        ArtifactDeployerEntry entry2 = new ArtifactDeployerEntry("i", "b", "e", "r", true, false, false, false);
+
+        assertEquals(entry1.getUniqueId(), entry2.getUniqueId());
+
+        entry2.setFailNoFilesDeploy(true);
+        assertNotEquals(entry1.getUniqueId(), entry2.getUniqueId());
+    }
+
+    @Test
+    void readObject_shouldMapLegacyDeletingRemoteFieldToDeleteRemote() throws Exception {
+        ArtifactDeployerEntry entry = new ArtifactDeployerEntry();
+        entry.setDeleteRemote(false);
+
+        java.lang.reflect.Field deletingRemote = ArtifactDeployerEntry.class.getDeclaredField("deletingRemote");
+        deletingRemote.setAccessible(true);
+        deletingRemote.setBoolean(entry, true);
+
+        Object returned = entry.readObject();
+
+        assertSame(entry, returned);
+        assertTrue(entry.isDeleteRemote());
+    }
+
+    @Test
+    void readObject_shouldKeepDeleteRemoteWhenLegacyFieldFalse() throws Exception {
+        ArtifactDeployerEntry entry = new ArtifactDeployerEntry();
+        entry.setDeleteRemote(true);
+
+        java.lang.reflect.Field deletingRemote = ArtifactDeployerEntry.class.getDeclaredField("deletingRemote");
+        deletingRemote.setAccessible(true);
+        deletingRemote.setBoolean(entry, false);
+
+        entry.readObject();
+
+        assertTrue(entry.isDeleteRemote());
+        entry.setDeleteRemote(false);
+        assertFalse(entry.isDeleteRemote());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerExceptionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerExceptionTest.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.artifactdeployer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ArtifactDeployerExceptionTest {
+
+    @Test
+    void defaultConstructor_shouldCreateExceptionWithoutMessageOrCause() {
+        ArtifactDeployerException ex = new ArtifactDeployerException();
+        assertNull(ex.getMessage());
+        assertNull(ex.getCause());
+    }
+
+    @Test
+    void messageConstructor_shouldStoreMessage() {
+        ArtifactDeployerException ex = new ArtifactDeployerException("boom");
+        assertEquals("boom", ex.getMessage());
+        assertNull(ex.getCause());
+    }
+
+    @Test
+    void messageAndCauseConstructor_shouldStoreBoth() {
+        RuntimeException cause = new RuntimeException("cause");
+        ArtifactDeployerException ex = new ArtifactDeployerException("boom", cause);
+
+        assertEquals("boom", ex.getMessage());
+        assertSame(cause, ex.getCause());
+    }
+
+    @Test
+    void causeConstructor_shouldStoreCause() {
+        RuntimeException cause = new RuntimeException("cause");
+        ArtifactDeployerException ex = new ArtifactDeployerException(cause);
+
+        assertSame(cause, ex.getCause());
+        assertEquals(cause.toString(), ex.getMessage());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerProjectActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerProjectActionTest.java
@@ -1,0 +1,17 @@
+package org.jenkinsci.plugins.artifactdeployer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ArtifactDeployerProjectActionTest {
+
+    @Test
+    void metadataMethods_shouldReturnExpectedValues() {
+        ArtifactDeployerProjectAction action = new ArtifactDeployerProjectAction(null);
+
+        assertEquals("package.gif", action.getIconFileName());
+        assertEquals("Last Successful Deployed Artifacts", action.getDisplayName());
+        assertEquals("lastSuccessfulBuild//deployedArtifacts", action.getUrlName());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerVOTest.java
+++ b/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerVOTest.java
@@ -1,0 +1,24 @@
+package org.jenkinsci.plugins.artifactdeployer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArtifactDeployerVOTest {
+
+    @Test
+    void settersAndGetters_shouldRoundTripValues() {
+        ArtifactDeployerVO vo = new ArtifactDeployerVO();
+
+        vo.setId(42);
+        vo.setFileName("archive.zip");
+        vo.setDeployed(true);
+        vo.setRemotePath("/tmp/archive.zip");
+
+        assertEquals(42, vo.getId());
+        assertEquals("archive.zip", vo.getFileName());
+        assertTrue(vo.isDeployed());
+        assertEquals("/tmp/archive.zip", vo.getRemotePath());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/artifactdeployer/DeployedArtifactsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/artifactdeployer/DeployedArtifactsTest.java
@@ -1,0 +1,53 @@
+package org.jenkinsci.plugins.artifactdeployer;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DeployedArtifactsTest {
+
+    @Test
+    void actionMetadata_shouldBeNullAsDeprecatedAction() {
+        DeployedArtifacts deployed = new DeployedArtifacts();
+
+        assertNull(deployed.getIconFileName());
+        assertNull(deployed.getDisplayName());
+        assertNull(deployed.getUrlName());
+    }
+
+    @Test
+    void deployedArtifactsInfo_shouldBeMutableMap() {
+        DeployedArtifacts deployed = new DeployedArtifacts();
+        Map<Integer, List<ArtifactDeployerVO>> info = deployed.getDeployedArtifactsInfo();
+
+        assertNotNull(info);
+        info.put(10, Collections.singletonList(new ArtifactDeployerVO()));
+
+        assertTrue(deployed.getDeployedArtifactsInfo().containsKey(10));
+        assertEquals(1, deployed.getDeployedArtifactsInfo().get(10).size());
+    }
+
+    @Test
+    void readResolve_shouldReturnArtifactDeployerBuildActionWithCopiedData() throws Exception {
+        DeployedArtifacts deployed = new DeployedArtifacts();
+        ArtifactDeployerVO vo = new ArtifactDeployerVO();
+        deployed.getDeployedArtifactsInfo().put(99, Collections.singletonList(vo));
+
+        Method readResolve = DeployedArtifacts.class.getDeclaredMethod("readResolve");
+        readResolve.setAccessible(true);
+        Object resolved = readResolve.invoke(deployed);
+
+        assertEquals(ArtifactDeployerBuildAction.class, resolved.getClass());
+        ArtifactDeployerBuildAction action = (ArtifactDeployerBuildAction) resolved;
+        assertTrue(action.getDeployedArtifactsInfo().containsKey(99));
+        assertEquals(1, action.getDeployedArtifactsInfo().get(99).size());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/artifactdeployer/service/ArtifactDeployerManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/artifactdeployer/service/ArtifactDeployerManagerTest.java
@@ -1,0 +1,53 @@
+package org.jenkinsci.plugins.artifactdeployer.service;
+
+import hudson.FilePath;
+import org.jenkinsci.plugins.artifactdeployer.ArtifactDeployerException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ArtifactDeployerManagerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void getBasedirFilePath_whenBasedirNull_shouldReturnWorkspace() {
+        ArtifactDeployerManager manager = new ArtifactDeployerManager();
+        FilePath workspace = new FilePath(tempDir.toFile());
+
+        FilePath result = manager.getBasedirFilePath(workspace, null);
+
+        assertSame(workspace, result);
+    }
+
+    @Test
+    void getBasedirFilePath_whenChildExists_shouldReturnChild() throws Exception {
+        ArtifactDeployerManager manager = new ArtifactDeployerManager();
+        FilePath workspace = new FilePath(tempDir.toFile());
+        Files.createDirectories(tempDir.resolve("dist"));
+
+        FilePath result = manager.getBasedirFilePath(workspace, "dist");
+
+        assertEquals(workspace.child("dist").getRemote(), result.getRemote());
+    }
+
+    @Test
+    void getBasedirFilePath_whenChildMissing_shouldThrowHelpfulException() {
+        ArtifactDeployerManager manager = new ArtifactDeployerManager();
+        FilePath workspace = new FilePath(tempDir.toFile());
+
+        ArtifactDeployerException exception = assertThrows(
+                ArtifactDeployerException.class,
+                () -> manager.getBasedirFilePath(workspace, "missing")
+        );
+
+        assertEquals("The basedir path 'missing' from the workspace doesn't exist.", exception.getMessage());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/artifactdeployer/service/LocalCopyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/artifactdeployer/service/LocalCopyTest.java
@@ -1,0 +1,56 @@
+package org.jenkinsci.plugins.artifactdeployer.service;
+
+import hudson.Util;
+import org.apache.tools.ant.types.FileSet;
+import org.jenkinsci.plugins.artifactdeployer.ArtifactDeployerException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocalCopyTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void copyAndGetNumbers_shouldCopyMatchingFiles() throws Exception {
+        Path sourceDir = Files.createDirectories(tempDir.resolve("src"));
+        Path targetDir = Files.createDirectories(tempDir.resolve("target"));
+        Files.writeString(sourceDir.resolve("a.txt"), "alpha");
+        Files.writeString(sourceDir.resolve("b.log"), "beta");
+
+        FileSet fileSet = Util.createFileSet(sourceDir.toFile(), "**/*.txt", null);
+
+        LocalCopy localCopy = new LocalCopy();
+        List<File> copied = localCopy.copyAndGetNumbers(fileSet, false, targetDir.toFile());
+
+        assertEquals(1, copied.size());
+        assertTrue(Files.exists(targetDir.resolve("a.txt")));
+        assertEquals("a.txt", copied.get(0).getName());
+    }
+
+    @Test
+    void copyAndGetNumbers_whenTargetIsFile_shouldWrapBuildException() throws Exception {
+        Path sourceDir = Files.createDirectories(tempDir.resolve("src2"));
+        Path targetFile = Files.writeString(tempDir.resolve("target-file.txt"), "not a directory");
+        Files.writeString(sourceDir.resolve("a.txt"), "alpha");
+
+        FileSet fileSet = Util.createFileSet(sourceDir.toFile(), "**/*.txt", null);
+        LocalCopy localCopy = new LocalCopy();
+
+        ArtifactDeployerException exception = assertThrows(
+                ArtifactDeployerException.class,
+                () -> localCopy.copyAndGetNumbers(fileSet, false, targetFile.toFile())
+        );
+
+        assertEquals("Error on copying file.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes all open code scanning security alerts (15 open alerts across 4 files).

## Changes

### ArtifactDeployerCopy — Unsafe Callable (alert #1)
- checkRoles() previously had an empty body, allowing the callable to run on any remoting endpoint
- Now calls oleChecker.check(this, Roles.SLAVE) to restrict execution to agents only

### DeployedArtifactsResult — Missing permission check (alert #17)
- doDownload() now calls getOwner().checkPermission(Item.READ) before serving any file
- Prevents unauthenticated/unauthorized users from downloading build artifacts

### ArtifactDeployerBuilder — CSRF + missing permission checks (alerts #7, #11, #12, #14)
- Added @POST to doCheckIncludes, doCheckExcludes, doCheckRemote
- Added project.checkPermission(Item.CONFIGURE) to doCheckIncludes and doCheckExcludes (which access the agent workspace)

### ArtifactDeployerPublisher — CSRF + missing permission checks (alerts #6, #9, #10, #13)
- Same fixes as ArtifactDeployerBuilder applied to the publisher descriptor

## Why

These were flagged by GitHub code scanning (CodeQL / Jenkins security rules). The fixes follow standard Jenkins plugin security guidance:
- Roles.SLAVE for FileCallable implementations that must only run on agents
- Item.READ / Item.CONFIGURE permission checks on Stapler action methods
- @POST on form validation methods that access agent workspaces

## Checklist

- [x] Compiles cleanly (mvn clean compile)
- [x] No functional behavior changes for authorized users
- [x] Follows Jenkins plugin security best practices