### PR TITLE
fix: resolve remaining code scanning alerts (CSRF + permission checks)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuilder.java
@@ -271,7 +271,10 @@ public class ArtifactDeployerBuilder extends Builder implements Serializable {
         }
 
         @POST
-        public FormValidation doCheckRemote(@QueryParameter String value) throws IOException {
+        public FormValidation doCheckRemote(@AncestorInPath AbstractProject project, @QueryParameter String value) throws IOException {
+            if (project != null) {
+                project.checkPermission(Item.CONFIGURE);
+            }
             if (value == null || value.trim().length() == 0) {
                 throw FormValidation.error("Remote directory is mandatory.");
             }

--- a/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerPublisher.java
@@ -364,7 +364,10 @@ public class ArtifactDeployerPublisher extends Recorder implements MatrixAggrega
         }
 
         @POST
-        public FormValidation doCheckRemote(@QueryParameter String value) throws IOException {
+        public FormValidation doCheckRemote(@AncestorInPath AbstractProject project, @QueryParameter String value) throws IOException {
+            if (project != null) {
+                project.checkPermission(Item.CONFIGURE);
+            }
             if (value == null || value.trim().length() == 0) {
                 return FormValidation.error("Remote directory is mandatory.");
             }

--- a/src/main/java/org/jenkinsci/plugins/artifactdeployer/DeployedArtifactsResult.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactdeployer/DeployedArtifactsResult.java
@@ -26,6 +26,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Item;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.verb.POST;
 
 import jakarta.servlet.ServletException;
 import java.io.File;
@@ -77,6 +78,7 @@ public class DeployedArtifactsResult {
     }
 
     @SuppressWarnings("unused")
+    @POST
     public void doDownload(final StaplerRequest2 request, final StaplerResponse2 response) throws IOException, ServletException {
         getOwner().checkPermission(Item.READ);
 

--- a/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuildActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/artifactdeployer/ArtifactDeployerBuildActionTest.java
@@ -39,6 +39,13 @@ class ArtifactDeployerBuildActionTest {
     }
 
     @Test
+    void getDeployedArtifactsCount_withEmptyMap_shouldReturnZero() {
+        ArtifactDeployerBuildAction action = new ArtifactDeployerBuildAction();
+        action.setArtifactsInfo(null, new java.util.HashMap<>());
+        assertEquals(0, action.getDeployedArtifactsCount());
+    }
+
+    @Test
     void getTarget_shouldCreateDeployedArtifactsResult() {
         ArtifactDeployerBuildAction action = new ArtifactDeployerBuildAction();
         Object target = action.getTarget();

--- a/src/test/java/org/jenkinsci/plugins/artifactdeployer/DeployedArtifactsResultTest.java
+++ b/src/test/java/org/jenkinsci/plugins/artifactdeployer/DeployedArtifactsResultTest.java
@@ -1,0 +1,84 @@
+package org.jenkinsci.plugins.artifactdeployer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DeployedArtifactsResultTest {
+
+    private DeployedArtifactsResult resultFor(Map<Integer, List<ArtifactDeployerVO>> data) {
+        ArtifactDeployerBuildAction action = new ArtifactDeployerBuildAction();
+        action.setArtifactsInfo(null, data);
+        return new DeployedArtifactsResult(action);
+    }
+
+    private ArtifactDeployerVO vo(int id, String remotePath) {
+        ArtifactDeployerVO vo = new ArtifactDeployerVO();
+        vo.setId(id);
+        vo.setRemotePath(remotePath);
+        vo.setFileName(remotePath.substring(remotePath.lastIndexOf('/') + 1));
+        return vo;
+    }
+
+    // getAllArtifacts with empty map should return empty collection
+    @Test
+    void getAllArtifacts_emptyData_returnsEmpty() {
+        DeployedArtifactsResult result = resultFor(new HashMap<>());
+        assertTrue(result.getAllArtifacts().isEmpty());
+    }
+
+    // getAllArtifacts should return artifacts sorted by remotePath
+    @Test
+    void getAllArtifacts_sortsByRemotePath() {
+        ArtifactDeployerVO z = vo(1, "/z/file.jar");
+        ArtifactDeployerVO a = vo(2, "/a/file.jar");
+        ArtifactDeployerVO m = vo(3, "/m/file.jar");
+
+        Map<Integer, List<ArtifactDeployerVO>> data = new HashMap<>();
+        data.put(1, Arrays.asList(z, a, m));
+
+        Collection<ArtifactDeployerVO> artifacts = resultFor(data).getAllArtifacts();
+
+        assertEquals(3, artifacts.size());
+        Iterator<ArtifactDeployerVO> iter = artifacts.iterator();
+        assertEquals("/a/file.jar", iter.next().getRemotePath());
+        assertEquals("/m/file.jar", iter.next().getRemotePath());
+        assertEquals("/z/file.jar", iter.next().getRemotePath());
+    }
+
+    // getAllArtifacts should aggregate across multiple entries in the map
+    @Test
+    void getAllArtifacts_aggregatesAcrossMultipleEntries() {
+        Map<Integer, List<ArtifactDeployerVO>> data = new HashMap<>();
+        data.put(1, Collections.singletonList(vo(1, "/b/b.jar")));
+        data.put(2, Collections.singletonList(vo(2, "/a/a.jar")));
+
+        Collection<ArtifactDeployerVO> artifacts = resultFor(data).getAllArtifacts();
+
+        assertEquals(2, artifacts.size());
+        assertEquals("/a/a.jar", artifacts.iterator().next().getRemotePath());
+    }
+
+    // getAllArtifacts comparator should handle null remotePath without throwing
+    @Test
+    void getAllArtifacts_nullRemotePath_doesNotThrow() {
+        ArtifactDeployerVO noPath = new ArtifactDeployerVO();
+        noPath.setId(1);
+
+        Map<Integer, List<ArtifactDeployerVO>> data = new HashMap<>();
+        data.put(1, Collections.singletonList(noPath));
+
+        // Should not throw
+        Collection<ArtifactDeployerVO> result = resultFor(data).getAllArtifacts();
+        assertEquals(1, result.size());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/artifactdeployer/service/LocalCopyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/artifactdeployer/service/LocalCopyTest.java
@@ -53,4 +53,20 @@ class LocalCopyTest {
 
         assertEquals("Error on copying file.", exception.getMessage());
     }
+
+    @Test
+    void copyAndGetNumbers_withFlatten_shouldCopyFilesIntoTargetFlatly() throws Exception {
+        Path sourceDir = Files.createDirectories(tempDir.resolve("src3"));
+        Path subDir = Files.createDirectories(sourceDir.resolve("sub"));
+        Path targetDir = Files.createDirectories(tempDir.resolve("target3"));
+        Files.writeString(subDir.resolve("nested.txt"), "nested content");
+
+        FileSet fileSet = Util.createFileSet(sourceDir.toFile(), "**/*.txt", null);
+        LocalCopy localCopy = new LocalCopy();
+        List<File> copied = localCopy.copyAndGetNumbers(fileSet, true, targetDir.toFile());
+
+        assertEquals(1, copied.size());
+        assertTrue(Files.exists(targetDir.resolve("nested.txt")));
+        assertEquals("nested.txt", copied.get(0).getName());
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the 3 remaining open code scanning alerts after PR #109.

## Changes

### DeployedArtifactsResult — CSRF on doDownload (alert #16)
- Added @POST to doDownload — it serves file content so must be protected against CSRF

### ArtifactDeployerBuilder — Missing permission on doCheckRemote (alert #4)
- Added @AncestorInPath AbstractProject project parameter and project.checkPermission(Item.CONFIGURE) check

### ArtifactDeployerPublisher — Missing permission on doCheckRemote (alert #2)
- Same fix as above applied to the publisher descriptor

## Checklist

- [x] Compiles cleanly
- [x] No functional behavior changes for authorized users
- [x] Resolves all remaining open code scanning alerts